### PR TITLE
Fix ArgumentError invalid byte sequence in UTF-8 error

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('json', '>= 1.5.1')
   s.add_dependency('active_utils', '>= 1.0.2')
   s.add_dependency('nokogiri')
+  s.add_dependency('itaiji')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha', '~> 0.11.3')

--- a/lib/active_merchant/billing/gateways/gmo_konbini.rb
+++ b/lib/active_merchant/billing/gateways/gmo_konbini.rb
@@ -15,7 +15,7 @@ module ActiveMerchant #:nodoc:
 
       def initialize(options = {})
         requires!(options, :shop_id, :password, :shop_name, :shop_phone, :shop_hours)
-        @shop_name = options[:shop_name].encode('Shift_JIS')
+        @shop_name = encode_shift_jis(options[:shop_name])
         @shop_phone = options[:shop_phone]
         @shop_hours = options[:shop_hours]
         super
@@ -105,11 +105,22 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_info( post, billing_address )
-        post[:CustomerName] = billing_address[:name].encode('Shift_JIS') # .. this this last+first
-        post[:CustomerKana] = billing_address[:kana].encode('Shift_JIS') # spree_kana specific
+        post[:CustomerName] = encode_shift_jis(billing_address[:name]) # .. this this last+first
+        post[:CustomerKana] = encode_shift_jis(billing_address[:kana]) # spree_kana specific
         post[:TelNo] = billing_address[:phone].gsub(/\D/,'')
+      end
+
+      def encode_shift_jis(japanese_text)
+        japanese_text.encode('Shift_JIS')
+      rescue Encoding::UndefinedConversionError
+        itaiji_converter.convert_seijitai(japanese_text).encode('Shift_JIS',
+                                                                :invalid => :replace,
+                                                                :undef => :replace)
+      end
+
+      def itaiji_converter
+        @converter ||= ::Itaiji::Converter.new
       end
     end
   end
 end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ require 'money'
 require 'mocha'
 require 'yaml'
 require 'json'
+require 'itaiji'
 require 'active_merchant'
 require 'comm_stub'
 

--- a/test/unit/gateways/gmo_konbini_test.rb
+++ b/test/unit/gateways/gmo_konbini_test.rb
@@ -1,0 +1,14 @@
+#encoding: utf-8
+require 'test_helper'
+
+class GmoKonbiniTest < Test::Unit::TestCase
+  def setup
+    @gateway = GmoKonbiniGateway.new(:shop_id => 'login', :password => 'password',
+                                     :shop_name => 'shop name', :shop_phone => '0300000000',
+                                     :shop_hours => '1 hour' )
+  end
+
+  def test_encode_shift_jis
+    assert_equal '高橋'.encode('Shift_JIS'), @gateway.send(:encode_shift_jis, '髙橋')
+  end
+end


### PR DESCRIPTION
### Before

```
options[:shop_name] = '野碕商店'
gateway = GmoKonbiniGateway.new(options) # ArgumentError invalid byte sequence in UTF-8
```
### After

```
options[:shop_name] = '野碕商店'
gateway = GmoKonbiniGateway.new(options) # Success
```
