### PR TITLE
Modify some dependent problems.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ notifications:
   hipchat:
     rooms:
       secure: gdprkPxgAfbKU4AJlCJ3R820Z6y+xOWAwt7+bT7DVsOSke3uMWOTzQ9bVKMb6n74R0cctq8mAYh28o5MJVxOiXNFNhHblhGdJlNxB9ZoDwLkQ6Kx/vDBGoLpqeBIA8EaD6FYCtoWBruZeu45TxR/ldYa22BjnmyNNL4acwegq/E=
+  slack: degica:5qSWYJuIKSySc5KqlxwIoNRd

--- a/Gemfile_common
+++ b/Gemfile_common
@@ -14,7 +14,7 @@ group :test, :remote_test do
   gem 'samurai', '>= 0.2.25'
   gem 'braintree', '>= 2.0.0'
   gem 'vindicia-api', :git => 'git://github.com/agoragames/vindicia-api.git', :ref => "4e78744c79cb97448ff46c21301f53b346db4c91"
-  gem 'LitleOnline', '>= 8.13.2'
+  gem 'LitleOnline', '>= 8.13.2', '< 8.25.0'
 end
 
 gem 'money', '5.0.0', :platforms => [:ruby_18]

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('money')
   s.add_dependency('builder', '>= 2.0.0')
   s.add_dependency('json', '>= 1.5.1')
-  s.add_dependency('active_utils', '>= 1.0.2')
+  s.add_dependency('active_utils', '>= 1.0.2', '<= 2.2.3')
   s.add_dependency('nokogiri')
   s.add_dependency('itaiji')
 


### PR DESCRIPTION
Because inversion 3.0 or higher, active_utils does not have
"ActiveMerchant::Validateable" class.But Credit class include it.

Modify LitleOnline gem version.
When this gem use its 8.25.0 or hihger, some test fail.
