### PR TITLE
Convert port to string because the error.

### DIFF
--- a/lib/active_merchant/billing/gateways/global_collect.rb
+++ b/lib/active_merchant/billing/gateways/global_collect.rb
@@ -173,7 +173,7 @@ module ActiveMerchant #:nodoc:
         proxy_env = ENV['http_proxy']
         if proxy_env
           proxy = URI.parse(proxy_env)
-          headers.merge!({http_proxyaddr: proxy.host, http_proxyport: proxy.port})
+          headers.merge!({http_proxyaddr: proxy.host, http_proxyport: proxy.port.to_s})
         end
         parse(ssl_post(url, xml, headers))
       end


### PR DESCRIPTION
error: NoMethodError: undefined method `strip' for 3128:Fixnum
It occured on
/usr/local/rbenv/versions/2.1.5/lib/ruby/2.1.0/net/http/header.rb:17:in
`block in initialize_http_header'.
