### PR TITLE
Add capture method that always returns success.

### DIFF
--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -38,6 +38,10 @@ module ActiveMerchant #:nodoc:
         commit(params)
       end
 
+      def capture(*args)
+        Response.new true, 'Success', {}, { test: test? }
+      end
+
       private
 
       def payment_details(payment, options)

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -38,6 +38,14 @@ class KomojuTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_konbini_capture
+    response = @gateway.capture(@amount, @konbini, @options)
+    assert_success response
+
+    assert_equal response.message, "Success"
+    assert response.test?
+  end
+
   def test_failed_purchase
     raw_response = mock
     raw_response.expects(:body).returns(JSON.generate(failed_purchase_response))


### PR DESCRIPTION
When capturing payments, we use the `capture!` method which in the `Spree::Payment::Processing` module calls `capture` on the payment method:

https://github.com/degica/spree/blob/47dbf70a8a9976c04749f58bd99b948b3bf32ef2/core/app/models/spree/payment/processing.rb#L44

By default, Spree delegates this `capture` method in `Spree::Gateway` to the (ActiveMerchant) provider:

https://github.com/degica/spree/blob/47dbf70a8a9976c04749f58bd99b948b3bf32ef2/core/app/models/spree/gateway.rb#L3

The `GmoKonbini` gateway just stubs this method to always return a success response:

https://github.com/komoju/active_merchant/blob/707799ed3fdb9ca062b6a99e0c24dbfa818d2c41/lib/active_merchant/billing/gateways/gmo_konbini.rb#L25

We could either add this `capture` method to the `Spree::Gateway::KomojuKonbini` class twice (one for each project) or add it here once; I opted for the latter.
