### PR TITLE
Update komoju gateway

### DIFF
--- a/test/remote/gateways/remote_komoju_test.rb
+++ b/test/remote/gateways/remote_komoju_test.rb
@@ -28,7 +28,11 @@ class RemoteKomojuTest < Test::Unit::TestCase
     @options = {
       :order_id => SecureRandom.uuid,
       :description => 'Store Purchase',
-      :tax => '10.0'
+      :tax => '10.0',
+      :ip => "192.168.0.1",
+      :email => "valid@email.com",
+      :browser_language => "en",
+      :browser_user_agent => "user_agent"
     }
   end
 
@@ -40,6 +44,15 @@ class RemoteKomojuTest < Test::Unit::TestCase
     assert_equal 100, response.params['amount']
     assert_equal "1111", response.params['payment_details']['last_four_digits']
     assert_equal true, response.params['succeeded']
+  end
+
+  def test_successful_credit_card_refund
+    purchase_response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase_response
+    assert purchase_response.authorization.present?
+    refund_response = @gateway.refund(@amount, purchase_response.authorization, {})
+    assert_success refund_response
+    assert_equal 'refunded', refund_response.params['status']
   end
 
   def test_successful_konbini_purchase

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -13,7 +13,15 @@ class KomojuTest < Test::Unit::TestCase
     }
     @amount = 100
 
-    @options = {:order_id => '1', :description => 'Store Purchase', :tax => "10"}
+    @options = {
+      :order_id => '1',
+      :description => 'Store Purchase',
+      :tax => "10",
+      :ip => "192.168.0.1",
+      :email => "valid@email.com",
+      :browser_language => "en",
+      :browser_user_agent => "user_agent"
+    }
   end
 
   def test_successful_credit_card_purchase
@@ -59,6 +67,17 @@ class KomojuTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_credit_card_refund
+    successful_response = successful_credit_card_refund_response
+    @gateway.expects(:ssl_post).returns(JSON.generate(successful_response))
+
+    response = @gateway.refund(@amount,  "7e8c55a54256ce23e387f2838c", @options)
+    assert_success response
+
+    assert_equal successful_response["id"], response.authorization
+    assert response.test?
+  end
+
   private
 
   def successful_credit_card_purchase_response
@@ -82,6 +101,35 @@ class KomojuTest < Test::Unit::TestCase
       "description" => "Store Purchase",
       "subscription" => nil,
       "succeeded" => true,
+      "captured_at" => "2015-03-20T04:51:48Z",
+      "metadata" => {
+        "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
+      },
+      "created_at" => "2015-03-20T04:51:48Z"
+    }
+  end
+
+  def successful_credit_card_refund_response
+    {
+      "id" => "7e8c55a54256ce23e387f2838c",
+      "resource" => "payment",
+      "status" => "refunded",
+      "amount" => 100,
+      "tax" => 8,
+      "payment_deadline" => nil,
+      "payment_details" => {
+        "type" => "credit_card",
+        "brand" => "visa",
+        "last_four_digits" => "2220",
+        "month" => 9,
+        "year" => 2016
+      },
+      "payment_method_fee" => 0,
+      "total" => 108,
+      "currency" => "JPY",
+      "description" => "Store Purchase",
+      "subscription" => nil,
+      "captured_at" => nil,
       "metadata" => {
         "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
       },
@@ -120,6 +168,7 @@ class KomojuTest < Test::Unit::TestCase
      "description" => nil,
      "subscription" => nil,
      "succeeded" => false,
+     "captured_at" => nil,
      "metadata" => {
        "order_id" => "262f2a92-542c-4b4e-a68b-5b6d54a438a8"
      },


### PR DESCRIPTION
I synced repo with `komoju/active_merchant`.
We can use `refund` and `fraud_details`.
