### PR TITLE
Fix missing email and add missing specs

### DIFF
--- a/lib/active_merchant/billing/gateways/komoju.rb
+++ b/lib/active_merchant/billing/gateways/komoju.rb
@@ -87,7 +87,9 @@ module ActiveMerchant #:nodoc:
           else
             post[:customer] = payment
           end
-        else
+        when Hash
+          details = payment
+          details[:email] = options[:email] if options[:email]
           post[:payment_details] = payment
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ end
 
 require 'test/unit'
 require 'money'
-require 'mocha'
+require 'mocha/setup'
 require 'yaml'
 require 'json'
 require 'itaiji'

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -28,7 +28,17 @@ class KomojuTest < Test::Unit::TestCase
     successful_response = successful_credit_card_purchase_response
     @gateway.expects(:ssl_post).with { |url, data|
       json = JSON.parse(data)
-      assert_equal @options[:email], json['payment_details']['email']
+      assert_equal 'credit_card',                  json['payment_details']['type']
+      assert_equal credit_card.number,             json['payment_details']['number']
+      assert_equal credit_card.month,              json['payment_details']['month']
+      assert_equal credit_card.year,               json['payment_details']['year']
+      assert_equal credit_card.verification_value, json['payment_details']['verification_value']
+      assert_equal credit_card.first_name,         json['payment_details']['given_name']
+      assert_equal credit_card.last_name,          json['payment_details']['family_name']
+      assert_equal @options[:email],               json['fraud_details']['customer_email']
+      assert_equal @options[:browser_language],    json['fraud_details']['browser_language']
+      assert_equal @options[:browser_user_agent],  json['fraud_details']['browser_user_agent']
+      assert_equal @options[:ip],                  json['fraud_details']['customer_ip']
     }.returns(JSON.generate(successful_response))
 
     response = @gateway.purchase(@amount, @credit_card, @options)
@@ -42,6 +52,7 @@ class KomojuTest < Test::Unit::TestCase
     successful_response = successful_konbini_purchase_response
     @gateway.expects(:ssl_post).with { |url, data|
       json = JSON.parse(data)
+      assert_equal 'konbini'    ,    json['payment_details']['type']
       assert_equal @options[:email], json['payment_details']['email']
     }.returns(JSON.generate(successful_response))
 

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -37,7 +37,10 @@ class KomojuTest < Test::Unit::TestCase
 
   def test_successful_konbini_purchase
     successful_response = successful_konbini_purchase_response
-    @gateway.expects(:ssl_post).returns(JSON.generate(successful_response))
+    @gateway.expects(:ssl_post).with { |url, data|
+      json = JSON.parse(data)
+      assert_equal @options[:email], json['payment_details']['email']
+    }.returns(JSON.generate(successful_response))
 
     response = @gateway.purchase(@amount, @konbini, @options)
     assert_success response

--- a/test/unit/gateways/komoju_test.rb
+++ b/test/unit/gateways/komoju_test.rb
@@ -26,7 +26,10 @@ class KomojuTest < Test::Unit::TestCase
 
   def test_successful_credit_card_purchase
     successful_response = successful_credit_card_purchase_response
-    @gateway.expects(:ssl_post).returns(JSON.generate(successful_response))
+    @gateway.expects(:ssl_post).with { |url, data|
+      json = JSON.parse(data)
+      assert_equal @options[:email], json['payment_details']['email']
+    }.returns(JSON.generate(successful_response))
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response


### PR DESCRIPTION
Specs were not checking request json values at all, so added some assertions to sanity-check we're sending what we need to send. This is not thorough but it's enough for now I think.